### PR TITLE
Adds a default "ALL" accounts view to SR Graph

### DIFF
--- a/src/games-graph/games-graph.component.html
+++ b/src/games-graph/games-graph.component.html
@@ -12,7 +12,8 @@
             <div class="panel-heading">
                 <ul class="nav nav-tabs">
                     <li class="{{ gamesLists && gamesLists.length > 1 ? '' : 'hidden' }}" ><b>Accounts:</b></li>
-                    <li class="{{ gamesLists && gamesLists.length > 1 ? '' : 'hidden' }} {{f ? 'active' : ''}}" *ngFor="let games of gamesLists; let f = first;"><a (click)="renderGraph(games.list)" href="#{{ playerHref(games) }}" data-toggle="tab">{{ games.player }}</a></li>
+                    <li class="{{ gamesLists && gamesLists.length > 1 ? '' : 'hidden' }} active"><a (click)="renderGraph(gamesLists)" href="#" data-toggle="tab">ALL</a></li>
+                    <li class="{{ gamesLists && gamesLists.length > 1 ? '' : 'hidden' }}" *ngFor="let games of gamesLists;"><a (click)="renderGraph([games])" href="#{{ playerHref(games) }}" data-toggle="tab">{{ games.player }}</a></li>
                 </ul>
             </div>
             <div class="tab-graph tab-pane active" id="sr-graph"></div>


### PR DESCRIPTION
This adds a default "ALL" accounts view to the SR Graph page. The existing account-specific tabs are still available, and should appear the same except that lines connecting games follow our new logic:

Previously, lines were drawn between game points unless Overtrack knew of a game between them that had an unknown SR (either due to error or being a placement game). Now, that condition still applies, but we also require that if a game's start SR is known, it must match the previous game's end SR in order for them to be connected by a line. (I interpreted the lines as indicating a block of games that were all known to be tracked properly, and tried to continue that logic to handle cases where some games are missed without Overtrack seeing an error.)

![](https://user-images.githubusercontent.com/18020/31101928-d7178f9e-a79d-11e7-9ad1-c1a45b5c1119.PNG)
![](https://user-images.githubusercontent.com/18020/31101931-d928be48-a79d-11e7-89ea-1b8e885ee2e3.PNG)
![](https://user-images.githubusercontent.com/18020/31101926-d52af22a-a79d-11e7-8567-e15e439572fb.PNG)
