### PR TITLE
Interpolates SR for placement/error games where possible

### DIFF
--- a/src/game/game.service.ts
+++ b/src/game/game.service.ts
@@ -501,14 +501,14 @@ export class Game {
     error: boolean;
     url: string;
     heroes: any;
-    rank: string;
+    rank: 'placement' | 'bronze' | 'silver' | 'gold' | 'platinum' | 'diamond';
     season: string;
     viewable: boolean;
 
     userID: number;
     map: string;
     mapType: string;
-    result: string;
+    result: 'UNKN' | 'WIN' | 'DRAW' | 'LOSS' | 'ERROR';
     startTime: Date;
     redScore: number;
     blueScore: number;

--- a/src/games-graph/games-graph.component.ts
+++ b/src/games-graph/games-graph.component.ts
@@ -7,6 +7,8 @@ import { Game } from '../game/game.service';
 
 declare var Plotly: any;
 
+type SRUnknownReason = null | 'placement' | 'error';
+
 @Component({
     selector: 'games-graph',
     templateUrl: './games-graph.component.html',
@@ -73,10 +75,6 @@ export class GamesGraphComponent implements OnInit {
         });
     }
 
-    formatLabel(game: Game) {
-        return game.result + ' - ' + game.map;
-    }
-
     graphableGamesLists(gameLists: Array<PlayerGameList>){
         if (!gameLists){
             return 
@@ -84,213 +82,112 @@ export class GamesGraphComponent implements OnInit {
         return gameLists.filter(gameList => gameList.list.filter(game => game.endSR != null).length >= 2);
     }
 
+    compareGamesChronologically(a: Game, b: Game): number {
+        // We add other sort keys to get deterministic results even when
+        // multiple games have the same startTime, which has previously
+        // happened as a result of errors.
+        return (+a.startTime - +b.startTime) || (a.duration - b.duration) || (a.key > b.key ? +1 : -1);
+    }
+
     renderGraph(gameLists: PlayerGameList[]): void {
-        const players = gameLists.map(l => l.player);
-
-        type GraphableGame = {
-            game: Game,
-            playerIndex: number,
-            connectedToNext: boolean
-        };
-
-        // All graphable games and their continuity in a single flattened sorted list.
-        const graphable: GraphableGame[] = [];
-
-        for (const gamesList of gameLists) {
-            let lastEntry: GraphableGame = null;
-            const playerIndex = players.indexOf(gamesList.player);
-            for (const game of Array.from(gamesList.list).reverse()) {
-                const entry = {
-                    game: game,
-                    playerIndex: playerIndex,
-                    connectedToNext: false
-                };
-
-                if (game.endSR && game.startTime) {
-                    graphable.push(entry);
-
-                    // We're connected if the previous game has an end SR and
-                    // the current game's start SR matches that end SR or is unknown.
-                    if (lastEntry && (game.startSR == null || game.startSR == lastEntry.game.endSR)) {
-                        lastEntry.connectedToNext = true;
-                    }
-                }
-
-                lastEntry = entry;
-            }
-        }
-
-        graphable.sort((a, b) => +a.game.startTime - +b.game.startTime);
-
-        // The data for the lines and dots for each account's games.
-        const playerLineXs: number[][] = players.map(_ => []);
-        const playerLineSRs: number[][] = players.map(_ => []);
-
-        const allXs: number[] = [];
-        const playerDotXs: number[][] = players.map(_ => []);
-        const playerDotSRs: number[][] = players.map(_ => []);
-        const playerDotLabels: string[][] = players.map(_ => []);
-        const playerDotGames: Game[][] = players.map(_ => []);
-
-        // The last-graphed entry for each account.
-        const playerLastEntries: GraphableGame[] = players.map(_ => null);
-
-        // Dates on the x-axis, common to all accounts.
-        let xAxisText: string[] = [];
-        let xAxisPoints: number[] = [];
-
         // A looping list of colors to use for different accounts on the graph.
-        const colors = ['#c19400', '#7560f2', '#c2004e', '#8ec200', '#008ec2', '#c2008e'];
+        // These must be rgba definitions ending in ', 1)' to allow opacity replacement below.
+        const colors = [
+            'rgba(255, 193, 0, 1)',
+            'rgba(117, 96, 242, 1)',
+            'rgba(194, 92, 78, 1)',
+            'rgba(142, 194, 0, 1)',
+            'rgba(0, 142, 194, 1)',
+            'rgba(194, 0, 142, 1)'
+        ];
 
-        let x = 0;
-        let lastDate: string = null;
-        let lastEntry = null;
-        for (const entry of graphable) {
-            const {playerIndex, game, connectedToNext} = entry;
+        // The number of recent games to show initially.
+        const initialGamesVisible = 100;
 
-            const playerLastEntry = playerLastEntries[playerIndex];
+        console.log('gamelists', gameLists);
 
-            if (playerLastEntry) {
-                if (playerLastEntry.connectedToNext) {
-                    if (playerLastEntry != lastEntry) {
-                        playerLineXs[playerIndex].push(x - 1);
-                        playerLineSRs[playerIndex].push(playerLastEntry.game.endSR);
-                    }
-                } else {
-                    playerLineXs[playerIndex].push(x);
-                    playerLineSRs[playerIndex].push(null);
+        // Data for each game, for each player.
+        const unfilteredGames = gameLists.map(x => ({
+            player: x.player,
+            games: x.list.slice().map(data => ({
+                data: data,
+                date: data.startTime,
+                sr: data.endSR || null,
+                srWasUnknownReason: (data.endSR ? null : data.rank == 'placement' ? 'placement' : 'error') as SRUnknownReason
+            })).sort((a, b) => this.compareGamesChronologically(a.data, b.data))
+        }));
 
-                    if (playerLastEntry == lastEntry) {
-                        // If we're immediately following a non-connected game on the same
-                        // account, insert a gap to make it clear they're separate.
-                        x++;
-                    }
-                }
-            }
+        // Estimate SR when possible for games that are missing it.
+        const gamesWithEstimates = unfilteredGames.map(x => ({
+            player: x.player,
+            games: this.fillUnknownSRs(x.games)
+        }));
 
-            playerDotXs[playerIndex].push(x);
-            playerDotSRs[playerIndex].push(game.endSR);
-            playerDotGames[playerIndex].push(game);
-            playerDotLabels[playerIndex].push(this.formatLabel(game));
+        // Filter out games without an SR (even estimated), and players with fewer than two eligible games.
+        const graphableGames = gamesWithEstimates
+            .map(x => ({
+                player: x.player,
+                games: x.games.filter(game => !!game.sr && !!game.date)
+            })).filter(x => x.games.length > 2);
 
-            if ((playerLastEntry && playerLastEntry.connectedToNext) || connectedToNext) {
-                playerLineXs[playerIndex].push(x);
-                allXs.push(x);
-                playerLineSRs[playerIndex].push(game.endSR);
-            }
+        // Indicies of all player arrays below, which will exclude filtered players.
+        const playerIndicies = graphableGames.map((l, i) => i);
 
-            const date: string = this.formatDate(entry.game.startTime);
-            if (lastDate != date){
-                xAxisText.push(date);
-                xAxisPoints.push(x);
-                lastDate = date;
-            }
+        // Player names.
+        const playerNames = graphableGames.map(l => l.player);
 
-            x++;
-            playerLastEntries[playerIndex] = entry;
-            lastEntry = entry;
+        // Each game's x coordinate is its index when sorted by date with all other graphable games.
+        const gamesWithXs = graphableGames.map(x => x.games.map(game => ({
+            x: NaN,
+            ...game
+        })));
+
+        type FullyAnnotatedGame = typeof gamesWithXs[0][0];
+
+        // Graphable games from all players, flattened into a single sorted array.
+        const allGames = gamesWithXs.reduce((a, b) => a.concat(b)).sort((a, b) => this.compareGamesChronologically(a.data, b.data));
+        const allXs: number[] = [];
+        for (let x = 0; x < allGames.length; x++) {
+            allGames[x].x = x;
+            allXs.push(x);
         }
 
-        // Sample the number of X axis tick values (i.e. dates) to be around 15
-        let nInM = Math.max(1, Math.round(xAxisText.length / 14))
-        xAxisText = xAxisText.filter((e, i) => i % nInM == 0)
-        xAxisPoints = xAxisPoints.filter((e, i) => i % nInM == 0)
-
-        // List of data series for Plotly.
-        const data: any[] = [];
-
-        // We need to specify the series in the order we want them drawn:
-        // lines under dots, then least-recent accounts under more-recent.
-        let colorIndex = 0;
-        for (let i = players.length - 1; i >= 0; i--) {
-            if (playerLineXs[i].length < 2){
-                continue;
-            }
-            const color = colors[colorIndex++ % colors.length];
-            data.push({
-                showlegend: false,
-                name: players[i],
-                legendgroup: players[i],
-                x: playerLineXs[i],
-                y: playerLineSRs[i],
-                mode: 'lines',
-                hoverinfo: 'skip',
-                line: {
-                    color: color
+        // Find all unique dates from all games.
+        let lastDateFormatted: string|null = null;
+        const allDates = allGames.map(game => {
+            const dateFormatted = this.formatDate(game.date);
+            if (dateFormatted != lastDateFormatted) {
+                lastDateFormatted = dateFormatted;
+                return {
+                    date: game.date,
+                    formatted: dateFormatted,
+                    x: game.x
                 }
-            });
-        }
-
-        colorIndex = 0;
-        for (let i = players.length - 1; i >= 0; i--) {
-            if (playerLineXs[i].length < 2){
-                continue;
+            } else {
+                return null;
             }
-            const color = colors[colorIndex++ % colors.length];
-            data.push({
-                name: players[i],
-                legendgroup: players[i],
-                x: playerDotXs[i],
-                y: playerDotSRs[i],
-                overtrackGames: playerDotGames[i],
-                text: playerDotLabels[i],
-                mode: 'markers',
-                hoverinfo: 'y+text',
-                marker: {
-                    size: 6,
-                    color: color,
-                }
-            });
-            
-        }
+        }).filter(Boolean);
 
         // We should probably reference this element in a more Angular way.
-        const plotEl = document.getElementById('sr-graph');
+        const plotlyElement = document.getElementById('sr-graph');
 
-        // set the initial zoom to include the last 100 games
-        const intitialLeft = allXs[Math.max(allXs.length - 100, 0)] - 0.5;
-        const initialRight = allXs[allXs.length - 1] + 1;
-
-        const calculateYAxisRange = (left: number, right: number): [number, number] => {
-            let gamesInRange = 0;
-            let minX = +Infinity;
-            let maxX = -Infinity;
-            let minSR = +Infinity;
-            let maxSR = -Infinity;
-
-            const defaultRange: [number, number] = [1000, 3000];
-
-            for (let playerIndex = 0; playerIndex < players.length; playerIndex++) {
-                for (let dotIndex = 0; dotIndex < playerDotXs[playerIndex].length; dotIndex++) {
-                    const x = playerDotXs[playerIndex][dotIndex];
-                    const sr = playerDotSRs[playerIndex][dotIndex];
-                    if (x >= left && x <= right) {
-                        gamesInRange++;
-                        if (sr < minSR) {
-                            minSR = sr;
-                        }
-                        if (sr > maxSR) {
-                            maxSR = sr;
-                        }
-                        if (x < minX) {
-                            minX = x;
-                        }
-                        if (x > maxX) {
-                            maxX = x;
-                        }
-                    }
-                }
+        // The game data, which will be populated below.
+        const plotlyData = [] as {
+            games: FullyAnnotatedGame[],
+            x: number[],
+            y: number[],
+            name: string,
+            showlegend: boolean,
+            legendgroup: string|null,
+            hoverinfo: string,
+            line: {
+                width: number,
+                color: string,
             }
+        }[];
 
-            if (gamesInRange == 0) {
-                return defaultRange;
-            } else {
-                const padding = 25;
-                return [minSR - padding, maxSR + padding];
-            }
-        };
-
-        const layout = {
+        // Layout settings, and axes whose values may be populated below.
+        const plotlyLayout = {
             title: '',
             font: {
                 color: 'rgb(150, 150, 150)'
@@ -299,21 +196,21 @@ export class GamesGraphComponent implements OnInit {
             dragmode: 'pan',
             xaxis: {
                 title: '',
-                
+
                 tickmode: 'array',
-                ticktext: xAxisText,
-                tickvals: xAxisPoints,
+                ticktext: [] as string[],
+                tickvals: [] as number[],
 
                 ticks: '',
                 showgrid: true,
                 gridcolor: 'rgba(0, 0, 0, 0.2)',
                 zeroline: false,
                 fixedrange: false,
-                range: [intitialLeft, initialRight]
+                range: [NaN, NaN] as [number, number]
             },
             yaxis: {
                 fixedrange: true,
-                range: calculateYAxisRange(intitialLeft, initialRight),
+                range: [NaN, NaN] as [number, number],
                 nticks: 3,
                 side: 'right'
             },
@@ -324,7 +221,7 @@ export class GamesGraphComponent implements OnInit {
                 b: 70,
                 t: 5
             },
-            showlegend: players.length > 1,
+            showlegend: false,
             legend: {
                 y: 100,
                 x: 0,
@@ -332,9 +229,11 @@ export class GamesGraphComponent implements OnInit {
             },
             plot_bgcolor: 'rgba(0, 0, 0, 0)',
             paper_bgcolor: 'rgba(0, 0, 0, 0)',
+            shapes: [] as any[]
         };
 
-        const config = {
+        // Plotly settings.
+        const plotlyConfig = {
             displayModeBar: false,
             staticPlot: false,
             doubleClick: false,
@@ -345,33 +244,240 @@ export class GamesGraphComponent implements OnInit {
             scrollZoom: true
         };
 
-        Plotly.newPlot(plotEl, data, layout, config);
+        // Sample the number of X axis tick values (i.e. dates) to be around 15.
+        const nInM = Math.max(1, Math.round(allDates.length / 14));
+        const sampledDates = allDates.filter((e, i) => i % nInM == 0);
 
-        (plotEl as any).on('plotly_click', data => {
+        // Add x ticks to the Plotly layout data.
+        for (const date of sampledDates) {
+            plotlyLayout.xaxis.tickvals.push(date.x);
+            plotlyLayout.xaxis.ticktext.push(date.formatted);
+        }
+
+        // Generate dot and line serises for each player.
+        const plotlyDataLines: any[] = [];
+        const plotlyDataDots: any[] = [];
+        const plotlyLayoutShapes: any[] = [];
+        for (const playerIndex of playerIndicies) {
+            const color = colors[playerIndex % colors.length];
+            const translucent = color.replace(', 1)', ', 0.5)');
+
+            const lineXs: number[] = [];
+            const lineSRs: number[] = [];
+
+            const dotXs: number[] = [];
+            const dotSRs: number[] = [];
+            const dotLabels: string[] = [];
+
+            const shapes: any[] = [];
+
+            const playerName = playerNames[playerIndex];
+            const games = gamesWithXs[playerIndex];
+
+            let lastGame: FullyAnnotatedGame = null;
+            for (const game of games) {
+                if (lastGame && (lastGame.x < game.x - 1)) {
+                    // If we're not immediately following the last game,
+                    // project its SR value forward to x - 1 so this game
+                    // only takes the typical amount of x-space (1).
+                    lineXs.push(game.x - 1);
+                    lineSRs.push(lastGame.sr);
+                }
+
+                lineXs.push(game.x);
+                lineSRs.push(game.sr);
+
+                let labelPrefix = '';
+                if (game.srWasUnknownReason) {
+                    labelPrefix = `SR estimated (${game.srWasUnknownReason})<br>`;
+                }
+                dotXs.push(game.x);
+                dotSRs.push(game.sr);
+                dotLabels.push(`${labelPrefix}${game.data.result} - ${game.data.map}`);
+
+                lastGame = game;
+            }
+
+            // Project SR line out beyond the end of the graph with latest value.
+            lineSRs.push(lineSRs[lineSRs.length - 1]);
+            lineXs.push(allXs[allXs.length - 1] + 1024);
+
+            plotlyDataLines.push({
+                showlegend: true,
+                name: playerName,
+                legendgroup: playerName,
+                x: lineXs,
+                y: lineSRs,
+                overtrackGames: games,
+                mode: 'lines',
+                hoverinfo: 'skip',
+                line: {
+                    width: 2,
+                    color: color,
+                }
+            });
+            
+            plotlyDataDots.push({
+                showlegend: false,
+                name: playerName,
+                legendgroup: playerName,
+                x: dotXs,
+                y: dotSRs,
+                overtrackGames: games,
+                text: dotLabels,
+                mode: 'markers',
+                hoverinfo: 'y+text',
+                marker: {
+                    size: 6,
+                    color: translucent
+                }
+            });
+
+            let runOfUnknownSRGames: null | FullyAnnotatedGame[] = [];
+            const outlineRun = () => {
+                let minSR = 5000;
+                let maxSR = 0;
+
+                for (const game of runOfUnknownSRGames) {
+                    if (game.sr < minSR) {
+                        minSR = game.sr;
+                    }
+                    if (game.sr > maxSR) {
+                        maxSR = game.sr;
+                    }
+                }
+
+                for (const game of runOfUnknownSRGames) {
+                    plotlyLayoutShapes.push({
+                        type: 'rect',
+                        xref: 'x',
+                        yref: 'y',
+                        x0: game.x - 0.5,
+                        x1: game.x + 0.5,
+                        y0: minSR - 25,
+                        y1: maxSR + 25,
+                        line: {
+                            width: 0,
+                            color: color,
+                        },
+                        layer: 'below',
+                        fillcolor: game.srWasUnknownReason == 'placement' ? 'rgba(0, 127, 255, 0.25)' : 'rgba(255, 0, 0, 0.125)',
+                    });
+                }
+            };
+            for (const game of games) {
+                if (game.srWasUnknownReason) {
+                    if (runOfUnknownSRGames) {
+                        runOfUnknownSRGames.push(game);
+                    } else {
+                        runOfUnknownSRGames = [game];
+                    }
+                } else {
+                    if (runOfUnknownSRGames) {
+                        outlineRun();
+                        runOfUnknownSRGames = null;
+                    }
+                }
+            }
+            if (runOfUnknownSRGames) {
+                outlineRun();
+            }
+        }
+
+        // Add the lines and dot series to the Plotly data (arguments go top-to-bottom).
+        plotlyData.unshift(...plotlyDataLines, ...plotlyDataDots);
+
+        // Add the shapes/outlines to the Plotly layout.
+        plotlyLayout.shapes.push(...plotlyLayoutShapes);
+
+        // Show the legend only if there are multiple players.
+        plotlyLayout.showlegend = playerIndicies.length > 1;
+
+        // Define limits for panning/zooming.
+        const minLeft = -2;
+        const maxRight = allXs[allXs.length - 1] + 2;
+        const maxRange = maxRight - minLeft;
+        const minRange = 2;
+        // Gets the closest legal X range and computed Y range for an input X range.
+        const getRanges = (left: number, right: number): {xRange: [number, number], yRange: [number, number]} => {
+            let range = right - left;
+
+            if (range > maxRange) {
+                const excess = range - maxRange;
+                range = maxRange;
+                left += excess / 2;
+                right -= excess / 2;
+            } else if (range < minRange) {
+                const shortfall = minRange - range;
+                range = minRange;
+                left -= shortfall / 2;
+                right += shortfall / 2;
+            }
+
+            if (left < minLeft) {
+                left = minLeft;
+                right = left + range;
+            } else if (right > maxRight) {
+                right = maxRight;
+                left = right - range;
+            }
+
+            let minSR = 5000;
+            let maxSR = 0;
+
+            for (const game of allGames) {
+                if (game.x >= left && game.x <= right) {
+                    if (game.sr < minSR) {
+                        minSR = game.sr;
+                    }
+                    if (game.sr > maxSR) {
+                        maxSR = game.sr;
+                    }
+                }
+            }
+
+            if (minSR >= maxSR) {
+                minSR = 0;
+                maxSR = 5000;
+            }
+
+            const yPadding = 25;
+
+            return {
+                xRange: [left, right],
+                yRange: [minSR - yPadding, maxSR + yPadding],
+            }
+        };
+
+        // Set the initial range to include the last 100 games.
+        const intitialLeft = allXs[Math.max(allXs.length - initialGamesVisible, 0)] - 0.5;
+        const initialRight = allXs[allXs.length - 1] + 1;
+        const initialRanges = getRanges(intitialLeft, initialRight);
+        plotlyLayout.xaxis.range = initialRanges.xRange;
+        plotlyLayout.yaxis.range = initialRanges.yRange;
+
+        // Initial Plotly render.
+        Plotly.newPlot(plotlyElement, plotlyData, plotlyLayout, plotlyConfig);
+
+        (plotlyElement as any).on('plotly_click', data => {
             if (data.points.length != 1) {
                 return;
             }
             if (!data.points[0].data.overtrackGames) {
                 return;
             }
-            const game:Game = data.points[0].data.overtrackGames[data.points[0].pointNumber];
-            if (!game.viewable) {
+            const game: FullyAnnotatedGame = data.points[0].data.overtrackGames[data.points[0].pointNumber];
+            if (!game.data.viewable) {
                 return;
             }
             if (data.event.ctrlKey){
-                window.open('./game/' + game.key);
+                window.open('./game/' + game.data.key);
             } else {
-                this.router.navigate(['/game/' + game.key]);
+                this.router.navigate(['/game/' + game.data.key]);
             }
         });
 
-        const minLeft = -1;
-        const maxRight = initialRight;
-        const maxRange = maxRight - minLeft;
-        const minRange = 2;
-        (plotEl as any).on('plotly_relayout', eventdata => {  
-
-            // prevent the user panning/zooming outside the range of games played
+        (plotlyElement as any).on('plotly_relayout', eventdata => {  
             let eventSource = 'user';
             if (eventdata['source']){
                 eventSource = eventdata['source'];
@@ -379,37 +485,182 @@ export class GamesGraphComponent implements OnInit {
 
             let left: number = eventdata['xaxis.range[0]'];
             let right: number = eventdata['xaxis.range[1]'];
-            if (right != undefined && left != undefined){
-                let range = right - left;
+            if (eventSource == 'user' && right != undefined && left != undefined){
+                const {xRange, yRange} = getRanges(left, right);
 
-                if (range > maxRange) {
-                    const excess = range - maxRange;
-                    range = maxRange;
-                    left += excess / 2;
-                    right -= excess / 2;
-                } else if (range < minRange) {
-                    const shortfall = minRange - range;
-                    range = minRange;
-                    left -= shortfall / 2;
-                    right += shortfall / 2;
-                }
-
-                if (left < minLeft) {
-                    left = minLeft;
-                    right = left + range;
-                } else if (right > maxRight) {
-                    right = maxRight;
-                    left = right - range;
-                }
-
-                if (eventSource == 'user'){
-                    Plotly.relayout(plotEl, {
-                        'source': 'constrainZoom',
-                        'xaxis.range': [left, right],
-                        'yaxis.range': calculateYAxisRange(left, right)
-                    });
-                }
+                Plotly.relayout(plotlyElement, {
+                    'source': 'constrainZoom',
+                    'xaxis.range': xRange,
+                    'yaxis.range': yRange
+                });
             }
         });
+    }
+    
+    // Attaches an estimated SR to games with unknown SR, where possible.
+    fillUnknownSRs<T extends {data: Game, sr: number}>(games: T[]): T[] {
+        // Create our copies of each game item, to be filled below.
+        const filled = games.map(game => (Object.assign({}, game)));
+
+        const srPerMatch = 25;
+        const delta = (r: typeof Game.prototype.result, winCoefficient: number = 1.0, lossCoefficient: number = 1.0) => {
+            if (r == 'WIN') {
+                return +srPerMatch * winCoefficient;
+            } else if (r == 'LOSS') {
+                return -srPerMatch * lossCoefficient;
+            } else if (r == 'DRAW') {
+                return 0;
+            } else {
+                return NaN;
+            }
+        }
+
+        // If we have a startSR and a result, use that to predict the end SR.
+        for (const entry of filled) {
+            if (!entry.sr) {
+                if (entry.data.startSR) {
+                    const result = entry.data.startSR + delta(entry.data.result);
+                    if (!isNaN(result)) {
+                        entry.sr = result;
+                    }
+                }
+            }
+        }
+
+        // If the next game has a startSR, use that for the current end SR.
+        let previous: T = null;
+        for (const entry of filled) {
+            if (previous && !previous.sr) {
+                if (entry.data.startSR) {
+                    previous.sr = entry.data.startSR;
+                }
+            }
+
+            previous = entry;
+        }
+
+        const unknownSegments: {
+            // the anchoring start and end SRs, if known.
+            start: number|null, // the SR *before/excluding* the first game
+            end: number|null, // the SR *after/including* the last game
+            games: T[][], // multiple games together are ties, merged for this
+        }[] = [];
+
+        let lastEntry: T = null;
+        let currentSegment: typeof unknownSegments[0] = null;
+
+        for (const entry of filled) {
+            if (currentSegment) {
+                if (entry.sr) {
+                    // end the current segment
+                    currentSegment.end = entry.data.startSR || entry.sr - (delta(entry.data.result) || 0);
+                    currentSegment = null;
+                } else {
+                    // continue current segment
+                    if (entry.data.result == 'DRAW') {
+                        // group with previous game
+                        currentSegment.games[currentSegment.games.length - 1].push(entry);
+                    } else {
+                        // append on its own
+                        currentSegment.games.push([entry]);
+                    }
+                }
+            } else {
+                if (entry.sr) {
+                    // carry on between segments
+                } else {
+                    // start new segment
+                    currentSegment = {
+                        start: lastEntry && lastEntry.sr || null,
+                        end: null,
+                        games: [[entry]]
+                    }
+                    unknownSegments.push(currentSegment);
+                }
+            }
+            lastEntry = entry;
+        }
+        
+        for (const unknown of unknownSegments) {
+            if (unknown.games.length == 0) {
+                // shouldn't happen.
+                continue;
+            }
+
+            if (!unknown.start && !unknown.end) {
+                // We have nothing to anchor an estimate at, so these remain unknown.
+                continue;
+            }
+
+            // The amount we predict these games will change the SR.
+            let naturalTotalDelta = 0;
+            let wins = 0;
+            let losses = 0;
+            let draws = 0;
+            let others = 0;
+            for (const entry of unknown.games) {
+                const result = entry[0].data.result;
+                naturalTotalDelta += delta(result) || 0;
+                if (result == 'WIN') wins++;
+                else if (result == 'LOSS') losses++;
+                else if (result == 'DRAW') draws++;
+                else others++;
+            }
+
+            if (!unknown.start || !unknown.end) {
+                // only one end is anchored, so we can just extrapolate without scaling.
+                if (!unknown.start) unknown.start = unknown.end - naturalTotalDelta;
+                if (!unknown.end) unknown.end = unknown.start + naturalTotalDelta;
+
+                let sr = unknown.start;
+                for (const games of unknown.games) {
+                    sr += delta(games[0].data.result) || 0;
+                    for (const game of games) {
+                        game.sr = Math.round(sr);
+                    }
+                }
+
+                continue;
+            }
+
+            // both ends are anchored, so we need to hit this target delta.
+            const knownDelta = unknown.end - unknown.start;
+
+            if (wins > 0 && losses > 0) {
+                // scale either wins or losses to be worth more in order to hit target.
+                let winCoefficient = 1.0;
+                let lossCoefficient = 1.0;
+                const lossesNaturalValue = - losses * srPerMatch;
+                const shortfall = knownDelta - naturalTotalDelta;
+                if (shortfall > 0) {
+                    winCoefficient += shortfall / wins / srPerMatch;
+                } else if (shortfall < 0) {
+                    lossCoefficient += -shortfall / losses / srPerMatch;
+                }
+
+                let sr = unknown.start;
+                for (const games of unknown.games) {
+                    sr += delta(games[0].data.result, winCoefficient, lossCoefficient) || 0;
+                    for (const game of games) {
+                        game.sr = Math.round(sr);
+                    }
+                }
+
+                continue;
+            }
+
+            // just put them in line from start to end, except for draws.
+            let sr = unknown.start;
+            for (const games of unknown.games) {
+                if (games[0].data.result != 'DRAW') {
+                    sr += knownDelta / (unknown.games.length - draws);
+                }
+                for (const game of games) {
+                    game.sr = Math.round(sr);
+                }
+            }
+        }
+
+        return filled;
     }
 }


### PR DESCRIPTION
Boxes are drawn around these games so users immediately see that they are not normal.

Also refactors `renderGraph()` to have a clearer more-functional data flow that will be easier to decompose.

Now draws lines between all of the player's games, instead of only blocks of known SR, since we now filling the gaps between most of those blocks in the common case (hopefully).

Makes dots translucent and moves them behind the lines.

![capture](https://user-images.githubusercontent.com/18020/31641503-0c645da6-b2b3-11e7-9cda-28ab604bd30e.PNG)
![capture 1](https://user-images.githubusercontent.com/18020/31641504-0c732304-b2b3-11e7-92ca-ce0e6837b592.PNG)
![capture 3](https://user-images.githubusercontent.com/18020/31641506-0c896268-b2b3-11e7-95bb-9735449c8725.PNG)
![capture 2](https://user-images.githubusercontent.com/18020/31641505-0c7e8064-b2b3-11e7-96a9-9ebfc179af5b.PNG)

At the bottom here, you can see the behaviour when the games are consecutive within an account, but interrupted by games on other accounts: there are gaps in the box. this is so we don't cover points on other accounts. but keeping the box size consistent despite the gap indicates that they're part of the same block.

The estimation logic produces pretty clean results in most cases, as you can see here, but in some edge cases where there are big SR swings in small number of games (usually because games are missing from Overtrack) you can end up with wins losing SR.