### PR TITLE
Includes x-axis grid lines for all dates, and dynamically sample dates in range to be labelled as you zoom and pan.

### DIFF
--- a/src/games-graph/games-graph.component.ts
+++ b/src/games-graph/games-graph.component.ts
@@ -154,8 +154,10 @@ export class GamesGraphComponent implements OnInit {
         let lastDateFormatted: string|null = null;
         const allDates = allGames.map(game => {
             const dateFormatted = this.formatDate(game.date);
+
             if (dateFormatted != lastDateFormatted) {
                 lastDateFormatted = dateFormatted;
+
                 return {
                     date: game.date,
                     formatted: dateFormatted,
@@ -241,16 +243,6 @@ export class GamesGraphComponent implements OnInit {
             displaylogo: false,
             scrollZoom: true
         };
-
-        // Sample the number of X axis tick values (i.e. dates) to be around 15.
-        const nInM = Math.max(1, Math.round(allDates.length / 14));
-        const sampledDates = allDates.filter((e, i) => i % nInM == 0);
-
-        // Add x ticks to the Plotly layout data.
-        for (const date of sampledDates) {
-            plotlyLayout.xaxis.tickvals.push(date.x);
-            plotlyLayout.xaxis.ticktext.push(date.formatted);
-        }
 
         // Generate dot and line serises for each player.
         const plotlyDataLines: any[] = [];
@@ -396,8 +388,14 @@ export class GamesGraphComponent implements OnInit {
         const maxRight = allXs[allXs.length - 1] + 2;
         const maxRange = maxRight - minLeft;
         const minRange = 2;
-        // Gets the closest legal X range and computed Y range for an input X range.
-        const getRanges = (left: number, right: number, enabledTraces: Array<string> | null): {xRange: [number, number], yRange: [number, number]} => {
+
+        // Returns layout properties that need to be updated to reflect a target X range.
+        const getLayout = (left: number, right: number, enabledTraces?: Array<string> | null): {
+            'xaxis.range': [number, number],
+            'yaxis.range': [number, number],
+            'xaxis.tickvals': number[],
+            'xaxis.ticktext': string[],
+        } => {
             let range = right - left;
 
             if (range > maxRange) {
@@ -424,9 +422,10 @@ export class GamesGraphComponent implements OnInit {
             let maxSR = 0;
 
             for (const game of allGames) {
-                if (enabledTraces && enabledTraces.indexOf(game.data.player) == -1){
+                if (enabledTraces && enabledTraces.indexOf(game.data.player) == -1) {
                     continue;
                 }
+
                 if (game.x >= left && game.x <= right) {
                     if (game.sr < minSR) {
                         minSR = game.sr;
@@ -442,20 +441,40 @@ export class GamesGraphComponent implements OnInit {
                 maxSR = 5000;
             }
 
+            // Sample approximately 15 dates currently in-range and label them on the x-axis.
+            const datesInRange = allDates.filter(d => d.x >= left && d.x <= right);
+            const nInM = Math.max(1, Math.round(datesInRange.length / 15));
+            const ticktext: string[] = [];
+            let i = 0;
+            for (const d of allDates) {
+                if (d.x >= left && d.x <= right) {
+                    if (i++ % nInM == 0) {
+                        ticktext.push(d.formatted);
+                        continue;
+                    }
+                }
+
+                ticktext.push('');
+            }
+
             const yPadding = 25;
 
             return {
-                xRange: [left, right],
-                yRange: [minSR - yPadding, maxSR + yPadding],
+                'xaxis.range': [left, right],
+                'yaxis.range': [minSR - yPadding, maxSR + yPadding],
+                'xaxis.ticktext': ticktext,
+                'xaxis.tickvals': allDates.map(d => d.x),
             }
         };
 
         // Set the initial range to include the last 100 games.
         const intitialLeft = allXs[Math.max(allXs.length - initialGamesVisible, 0)] - 0.5;
         const initialRight = allXs[allXs.length - 1] + 1;
-        const initialRanges = getRanges(intitialLeft, initialRight, null);
-        plotlyLayout.xaxis.range = initialRanges.xRange;
-        plotlyLayout.yaxis.range = initialRanges.yRange;
+        const initialLayout = getLayout(intitialLeft, initialRight, null);
+        plotlyLayout.xaxis.range = initialLayout['xaxis.range'];
+        plotlyLayout.yaxis.range = initialLayout['yaxis.range'];
+        plotlyLayout.xaxis.tickvals = initialLayout['xaxis.tickvals'];
+        plotlyLayout.xaxis.ticktext = initialLayout['xaxis.ticktext'];
 
         // Initial Plotly render.
         Plotly.newPlot(plotlyElement, plotlyData, plotlyLayout, plotlyConfig);
@@ -488,12 +507,10 @@ export class GamesGraphComponent implements OnInit {
             let right: number = eventdata['xaxis.range[1]'];
             if (eventSource == 'user' && right != undefined && left != undefined){
                 const enabledTraces: Array<string> = (plotlyElement as any).data.filter(e => e.showlegend == false && e.visible != 'legendonly').map(e => e.name);
-                const {xRange, yRange} = getRanges(left, right, enabledTraces);
 
                 Plotly.relayout(plotlyElement, {
-                    'source': 'constrainZoom',
-                    'xaxis.range': xRange,
-                    'yaxis.range': yRange
+                    source: 'constrainZoom',
+                    ...getLayout(left, right, enabledTraces)
                 });
             }
         });
@@ -502,12 +519,10 @@ export class GamesGraphComponent implements OnInit {
             let left: number = (plotlyElement as any).layout.xaxis.range[0];
             let right: number = (plotlyElement as any).layout.xaxis.range[1];
             const enabledTraces: Array<string> = (plotlyElement as any).data.filter(e => e.showlegend == false && e.visible != 'legendonly').map(e => e.name);
-            const {xRange, yRange} = getRanges(left, right, enabledTraces);
 
             Plotly.relayout(plotlyElement, {
-                'source': 'constrainZoom',
-                'xaxis.range': xRange,
-                'yaxis.range': yRange
+                source: 'constrainZoom',
+                ...getLayout(left, right, enabledTraces)
             });
         });
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -782,3 +782,8 @@ svg .timeline-event:hover {
 svg {
     overflow: visible !important;
 }
+
+#sr-graph {
+    /* give a bit more room for overflowing x-axis labels */
+    margin-bottom: 20px;
+}


### PR DESCRIPTION
We originally started sampling dates before adding zooming. Now that we have it, players will see a varying (typically smaller) number of date labels in usual use, because only a fraction of the sample dates will be in their initially visible range.

This change does two things: it restore the tick marks for all days, so that games in a single day (which often corresponds to a session) can be easily grouped at a glance at all zoom levels. It also re-samples approximately 15 dates **that are currently in range** as we zoom/pan. So we get as much detail as we want when we zoom in, without clutter in the zoomed-out view.
