### PR TITLE
Making games list rows more uniform and adding a compact view toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "core-js": "^2.5.7",
     "d3": "^5.0.0",
     "hls.js": "^0.11.0",
+    "moment": "^2.24.0",
     "ng-multiselect-dropdown": "^0.2.3",
     "raven-js": "^3.27.0",
     "rxjs": "^6.3.3",

--- a/prerender.css
+++ b/prerender.css
@@ -365,40 +365,6 @@ border-bottom-color: transparent;
   padding-bottom: 0px;
 }
 
-#gametable .gn {
-  font-size:18px;
-}
-
-#gametable .sr {
-  font-size:25px;
-  line-height:30px;
-  padding-top:5px;
-  padding-bottom:0px;
-}
-
-#gametable .sr > img {
-  height:45px;
-}
-
-#gametable .sr > span {
-  line-height: 25px;
-}
-
-#gametable .time {
-  padding-top:0px;
-  padding-bottom:0px;
-}
-
-#gametable .time > .num {
-  font-size:25px;
-  line-height: 18px;
-  padding-top: 8px;
-}
-
-#gametable .time > .unit{
-  font-size: 18px;
-}
-
 .unit {
   font-size: 20px; 
 }
@@ -493,7 +459,7 @@ border-bottom-color: transparent;
 }
 
 #gametable .hero > img {
-  height: 50px;
+  height: 48px;
 }
 
 div#meta-game div.panel-heading {

--- a/src/games-list/games-list.component.html
+++ b/src/games-list/games-list.component.html
@@ -26,10 +26,10 @@
     <div class="row col-md-12">
         <div class="panel panel-default control-panel">
             <div class="panel-heading">
-                <div class="col-xs-5">
+                <div class="col-xs-6">
                     <h2 class="col-xs-3">Games</h2>
                     <ng-multiselect-dropdown
-                        class="col-xs-9"
+                        class="col-xs-9 season-selector"
                         [data]="allSeasons"
                         [(ngModel)]="visibleSeasons"
                         [settings]="dropdownSettings"
@@ -40,8 +40,8 @@
                       >
                       </ng-multiselect-dropdown>
                 </div>
-                <div class="view-mode-buttons col-xs-2">
-                    <div class="btn-group btn-group-toggle" data-toggle="buttons">
+                <div *ngIf="isOwnGames" class="col-xs-6">
+                    <div class="btn-group btn-group-toggle pull-left view-mode-buttons" data-toggle="buttons">
                       <label class="btn btn-primary{{ isCompactView ? '' : ' active' }}" (click)="setIsCompact(false)">
                           <input type="radio" name="view-mode" class="btn btn-primary" id="thick-button">
                           <i class="glyphicon glyphicon-th-list"></i>
@@ -51,8 +51,7 @@
                           <i class="glyphicon glyphicon-list"></i>
                       </label>
                     </div>
-                </div>
-                <div *ngIf="isOwnGames" class="col-xs-5">
+
                     <share-links [accounts]="accountNames" class="pull-right"></share-links>
                     <integrations [accounts]="accountNames" class="pull-right"></integrations>
                     <button class="btn btn-primary pull-right" data-toggle="modal" data-target="#batch-edit">

--- a/src/games-list/games-list.component.html
+++ b/src/games-list/games-list.component.html
@@ -109,19 +109,7 @@
             </div>
             <div class="panel-body">
                 <div class="tab-content">
-                    <table *ngFor="let gamesOfDay of gamesByDay" class="table table-striped text-center">
-                        <thead>
-                            <tr class="date-row"><td colspan="8">{{gamesOfDay[0].listView.formatDate}}</td></tr>
-                            <tr style="width:100%">
-                                <th>Game Time</th>
-                                <th colspan="2">Win/Loss/Draw</th>
-                                <th>Score</th>
-                                <th *ngIf="!hideSR">Skill Rating</th>
-                                <th>Length</th>
-                                <th>Map</th>
-                                <th>Heroes</th>
-                            </tr>
-                        </thead>
+                    <table class="table table-striped text-center">
                         <tr *ngIf="currentUploadRequested && currentUserID == games.user_id">
                             <td class="gn">{{formatTime(currentUploadRequested)}} {{ formatDay(currentUploadRequested) }}<br>
                                 {{formatDate(currentUploadRequested)}}
@@ -130,48 +118,60 @@
                                 <p>Game uploading...</p>
                             </td> 
                         </tr>
-                        <tr *ngFor="let game of gamesOfDay; trackBy: myTrackByFunction"
-                            id="game-{{ game.num }}"
-                            class="list-game"
-                            [class.sub-required]="!game.viewable"
-                            [class.hoverable]="!game.error"
-                            (mousedown)="prepRoute(game, $event)"
-                            (mouseup)="route(game, $event)"
-                            data-toggle="popover"
-                            tabindex="0"
-                        >
-                            <p display="False" style="display: none;">
-                                {{ game.key }}
-                            </p>
-                            <td class="gn">{{game.listView.formatTime}}</td>
-                            <td *ngIf="!game.error && !hideSR" class="{{game.listView.wltClass}} text-right num">
-                                <b>{{ game.listView.srChange }}</b>
-                            </td>
-                            <td *ngIf="!game.error && hideSR"></td>
-                            <td *ngIf="!game.error" class="{{game.listView.wltClass}} text-left" >{{ game.result }}</td>
-                            <td *ngIf="!game.error"><span class="num">{{ game.blueScore }}</span>/<span class="num">{{ game.redScore }}</span></td>
-                            <td *ngIf="!game.error && game.rank == 'placement' && !game.endSR && !hideSR" class="num sr"><img src="assets/images/icons/placement.png"/><span>&nbsp;&nbsp;&nbsp;&nbsp;</span></td>
-                            <td *ngIf="!game.error && (game.rank != 'placement' || game.endSR) && !hideSR" class="num sr"><img src="assets/images/icons/{{ game.listView.rank }}.png"/><span>{{ game.listView.formatSR }}</span></td>
-                            <td *ngIf="!game.error" class="time"><div class="num">{{ getFormattedDuration(game) }}</div></td>
-                            <td *ngIf="!game.error" class="map {{map(game)}}">
-                                <div class="map-wrap">
-                                    <div class="map-bg bg"></div>
-                                    <div class="map-title">
-                                        <div class="map-title-bg bg"></div>
-                                        <i>{{ game.map }}</i>
+                        <tbody *ngFor="let gamesOfDay of gamesByDay">
+                            <tr class="date-row"><th colspan="8">{{gamesOfDay[0].listView.formatDate}}</th></tr>
+                            <tr style="width:100%">
+                              <th>Game Time</th>
+                              <th colspan="2">Win/Loss/Draw</th>
+                              <th>Score</th>
+                              <th *ngIf="!hideSR">Skill Rating</th>
+                              <th>Length</th>
+                              <th>Map</th>
+                              <th>Heroes</th>
+                            </tr>
+                            <tr *ngFor="let game of gamesOfDay; trackBy: myTrackByFunction"
+                                id="game-{{ game.num }}"
+                                class="list-game"
+                                [class.sub-required]="!game.viewable"
+                                [class.hoverable]="!game.error"
+                                (mousedown)="prepRoute(game, $event)"
+                                (mouseup)="route(game, $event)"
+                                data-toggle="popover"
+                                tabindex="0"
+                            >
+                                <p display="False" style="display: none;">
+                                    {{ game.key }}
+                                </p>
+                                <td class="gn">{{game.listView.formatTime}}</td>
+                                <td *ngIf="!game.error && !hideSR" class="{{game.listView.wltClass}} text-right num">
+                                    <b>{{ game.listView.srChange }}</b>
+                                </td>
+                                <td *ngIf="!game.error && hideSR"></td>
+                                <td *ngIf="!game.error" class="{{game.listView.wltClass}} text-left" >{{ game.result }}</td>
+                                <td *ngIf="!game.error"><span class="num">{{ game.blueScore }}</span>/<span class="num">{{ game.redScore }}</span></td>
+                                <td *ngIf="!game.error && game.rank == 'placement' && !game.endSR && !hideSR" class="num sr"><img src="assets/images/icons/placement.png"/><span>&nbsp;&nbsp;&nbsp;&nbsp;</span></td>
+                                <td *ngIf="!game.error && (game.rank != 'placement' || game.endSR) && !hideSR" class="num sr"><img src="assets/images/icons/{{ game.listView.rank }}.png"/><span>{{ game.listView.formatSR }}</span></td>
+                                <td *ngIf="!game.error" class="time"><div class="num">{{ getFormattedDuration(game) }}</div></td>
+                                <td *ngIf="!game.error" class="map {{map(game)}}">
+                                    <div class="map-wrap">
+                                        <div class="map-bg bg"></div>
+                                        <div class="map-title">
+                                            <div class="map-title-bg bg"></div>
+                                            <i>{{ game.map }}</i>
+                                        </div>
                                     </div>
-                                </div>
-                            </td>
-                            <td *ngIf="!game.error" class="hero" style="position: relative">
-                                <img *ngFor="let hero of game.heroes" src="assets/images/heroes/{{hero.name}}.png"/>
-                                <span *ngIf="isOwnGames" (mousedown)="edit(game, $event)" class="game-edit glyphicon glyphicon-pencil"></span>
-                            </td>
-                            <td *ngIf="game.error" colspan="2" class="{{game.listView.wltClass}} text-left">{{game.result}}</td>
-                            <td *ngIf="game.error" colspan="5" class="error-message text-error">
-                                <p>Game uploaded but failed to process. This is a bug. Please report this with the following game key: </p>
-                                <pre>{{ game.key }}</pre>
-                            </td>
-                        </tr>
+                                </td>
+                                <td *ngIf="!game.error" class="hero" style="position: relative">
+                                    <img *ngFor="let hero of game.heroes" src="assets/images/heroes/{{hero.name}}.png"/>
+                                    <span *ngIf="isOwnGames" (mousedown)="edit(game, $event)" class="game-edit glyphicon glyphicon-pencil"></span>
+                                </td>
+                                <td *ngIf="game.error" colspan="2" class="{{game.listView.wltClass}} text-left">{{game.result}}</td>
+                                <td *ngIf="game.error" colspan="5" class="error-message text-error">
+                                    <p>Game uploaded but failed to process. This is a bug. Please report this with the following game key: </p>
+                                    <pre>{{ game.key }}</pre>
+                                </td>
+                            </tr>
+                        </tbody>
                     </table>
                 </div>
             </div>

--- a/src/games-list/games-list.component.html
+++ b/src/games-list/games-list.component.html
@@ -110,15 +110,17 @@
             <div class="panel-body">
                 <div class="tab-content">
                     <table class="table table-striped text-center">
-                        <tr style="width:100%">
-                            <th>Game Time</th>
-                            <th colspan="2">Win/Loss/Draw</th>
-                            <th>Score</th>
-                            <th *ngIf="!hideSR">Skill Rating</th>
-                            <th>Length</th>
-                            <th>Map</th>
-                            <th>Heroes</th>
-                        </tr>
+                        <thead>
+                            <tr style="width:100%">
+                                <th>Game Time</th>
+                                <th colspan="2">Win/Loss/Draw</th>
+                                <th>Score</th>
+                                <th *ngIf="!hideSR">Skill Rating</th>
+                                <th>Length</th>
+                                <th>Map</th>
+                                <th>Heroes</th>
+                            </tr>
+                        </thead>
                         <tr *ngIf="currentUploadRequested && currentUserID == games.user_id">
                             <td class="gn">{{formatTime(currentUploadRequested)}} {{ formatDay(currentUploadRequested) }}<br>
                                 {{formatDate(currentUploadRequested)}}
@@ -127,50 +129,51 @@
                                 <p>Game uploading...</p>
                             </td> 
                         </tr>
-                        <tr *ngFor="let game of visibleGames; trackBy: myTrackByFunction"
-                            id="game-{{ game.num }}"
-                            class="list-game"
-                            [class.sub-required]="!game.viewable"
-                            [class.hoverable]="!game.error"
-                            (mousedown)="prepRoute(game, $event)" 
-                            (mouseup)="route(game, $event)"  
-                            data-toggle="popover"
-                            tabindex="0"
-                        >
-                            <p display="False" style="display: none;">
-                                {{ game.key }}
-                            </p>
-                            <td class="gn">{{game.listView.formatTime}} {{game.listView.formatDay}}<br>
-                                {{game.listView.formatDate}}
-                            </td>
-                            <td *ngIf="!game.error && !hideSR" class="{{game.listView.wltClass}} text-right num">
-                                <b>{{ game.listView.srChange }}</b>
-                            </td>
-                            <td *ngIf="!game.error && hideSR"></td>
-                            <td *ngIf="!game.error" class="{{game.listView.wltClass}} text-left" >{{ game.result }}</td>
-                            <td *ngIf="!game.error"><span class="num">{{ game.blueScore }}</span>/<span class="num">{{ game.redScore }}</span></td>
-                            <td *ngIf="!game.error && game.rank == 'placement' && !game.endSR && !hideSR" class="num sr"><img src="assets/images/icons/placement.png"/><span>&nbsp;&nbsp;&nbsp;&nbsp;</span></td>
-                            <td *ngIf="!game.error && (game.rank != 'placement' || game.endSR) && !hideSR" class="num sr"><img src="assets/images/icons/{{ game.listView.rank }}.png"/><span>{{ game.listView.formatSR }}</span></td>
-                            <td *ngIf="!game.error" class="time"><div class="num">{{ min(game) }}</div><div class="unit">min</div></td>
-                            <td *ngIf="!game.error" class="map {{map(game)}}">
-                                <div class="map-wrap">
-                                    <div class="map-bg bg"></div>
-                                    <div class="map-title">
-                                        <div class="map-title-bg bg"></div>
-                                        <i>{{ game.map }}</i>
+                        <tbody *ngFor="let gamesOfDay of gamesByDay">
+                            <tr class="date-row"><td colspan="8">{{gamesOfDay[0].listView.formatDate}}</td></tr>
+                            <tr *ngFor="let game of gamesOfDay; trackBy: myTrackByFunction"
+                                id="game-{{ game.num }}"
+                                class="list-game"
+                                [class.sub-required]="!game.viewable"
+                                [class.hoverable]="!game.error"
+                                (mousedown)="prepRoute(game, $event)"
+                                (mouseup)="route(game, $event)"
+                                data-toggle="popover"
+                                tabindex="0"
+                            >
+                                <p display="False" style="display: none;">
+                                    {{ game.key }}
+                                </p>
+                                <td class="gn">{{game.listView.formatTime}}</td>
+                                <td *ngIf="!game.error && !hideSR" class="{{game.listView.wltClass}} text-right num">
+                                    <b>{{ game.listView.srChange }}</b>
+                                </td>
+                                <td *ngIf="!game.error && hideSR"></td>
+                                <td *ngIf="!game.error" class="{{game.listView.wltClass}} text-left" >{{ game.result }}</td>
+                                <td *ngIf="!game.error"><span class="num">{{ game.blueScore }}</span>/<span class="num">{{ game.redScore }}</span></td>
+                                <td *ngIf="!game.error && game.rank == 'placement' && !game.endSR && !hideSR" class="num sr"><img src="assets/images/icons/placement.png"/><span>&nbsp;&nbsp;&nbsp;&nbsp;</span></td>
+                                <td *ngIf="!game.error && (game.rank != 'placement' || game.endSR) && !hideSR" class="num sr"><img src="assets/images/icons/{{ game.listView.rank }}.png"/><span>{{ game.listView.formatSR }}</span></td>
+                                <td *ngIf="!game.error" class="time"><div class="num">{{ getFormattedDuration(game) }}</div></td>
+                                <td *ngIf="!game.error" class="map {{map(game)}}">
+                                    <div class="map-wrap">
+                                        <div class="map-bg bg"></div>
+                                        <div class="map-title">
+                                            <div class="map-title-bg bg"></div>
+                                            <i>{{ game.map }}</i>
+                                        </div>
                                     </div>
-                                </div>
-                            </td>
-                            <td *ngIf="!game.error" class="hero" style="position: relative">
-                                <img *ngFor="let hero of game.heroes" src="assets/images/heroes/{{hero.name}}.png"/>
-                                <span *ngIf="isOwnGames" (mousedown)="edit(game, $event)" class="game-edit glyphicon glyphicon-pencil"></span>
-                            </td>
-                            <td *ngIf="game.error" colspan="2" class="{{game.listView.wltClass}} text-left">{{game.result}}</td>
-                            <td *ngIf="game.error" colspan="5" class="error-message text-error">
-                                <p>Game uploaded but failed to process. This is a bug. Please report this with the following game key: </p>
-                                <pre>{{ game.key }}</pre>
-                            </td> 
-                        </tr>
+                                </td>
+                                <td *ngIf="!game.error" class="hero" style="position: relative">
+                                    <img *ngFor="let hero of game.heroes" src="assets/images/heroes/{{hero.name}}.png"/>
+                                    <span *ngIf="isOwnGames" (mousedown)="edit(game, $event)" class="game-edit glyphicon glyphicon-pencil"></span>
+                                </td>
+                                <td *ngIf="game.error" colspan="2" class="{{game.listView.wltClass}} text-left">{{game.result}}</td>
+                                <td *ngIf="game.error" colspan="5" class="error-message text-error">
+                                    <p>Game uploaded but failed to process. This is a bug. Please report this with the following game key: </p>
+                                    <pre>{{ game.key }}</pre>
+                                </td>
+                            </tr>
+                        </tbody>
                     </table>
                 </div>
             </div>

--- a/src/games-list/games-list.component.html
+++ b/src/games-list/games-list.component.html
@@ -109,8 +109,9 @@
             </div>
             <div class="panel-body">
                 <div class="tab-content">
-                    <table class="table table-striped text-center">
+                    <table *ngFor="let gamesOfDay of gamesByDay" class="table table-striped text-center">
                         <thead>
+                            <tr class="date-row"><td colspan="8">{{gamesOfDay[0].listView.formatDate}}</td></tr>
                             <tr style="width:100%">
                                 <th>Game Time</th>
                                 <th colspan="2">Win/Loss/Draw</th>
@@ -129,51 +130,48 @@
                                 <p>Game uploading...</p>
                             </td> 
                         </tr>
-                        <tbody *ngFor="let gamesOfDay of gamesByDay">
-                            <tr class="date-row"><td colspan="8">{{gamesOfDay[0].listView.formatDate}}</td></tr>
-                            <tr *ngFor="let game of gamesOfDay; trackBy: myTrackByFunction"
-                                id="game-{{ game.num }}"
-                                class="list-game"
-                                [class.sub-required]="!game.viewable"
-                                [class.hoverable]="!game.error"
-                                (mousedown)="prepRoute(game, $event)"
-                                (mouseup)="route(game, $event)"
-                                data-toggle="popover"
-                                tabindex="0"
-                            >
-                                <p display="False" style="display: none;">
-                                    {{ game.key }}
-                                </p>
-                                <td class="gn">{{game.listView.formatTime}}</td>
-                                <td *ngIf="!game.error && !hideSR" class="{{game.listView.wltClass}} text-right num">
-                                    <b>{{ game.listView.srChange }}</b>
-                                </td>
-                                <td *ngIf="!game.error && hideSR"></td>
-                                <td *ngIf="!game.error" class="{{game.listView.wltClass}} text-left" >{{ game.result }}</td>
-                                <td *ngIf="!game.error"><span class="num">{{ game.blueScore }}</span>/<span class="num">{{ game.redScore }}</span></td>
-                                <td *ngIf="!game.error && game.rank == 'placement' && !game.endSR && !hideSR" class="num sr"><img src="assets/images/icons/placement.png"/><span>&nbsp;&nbsp;&nbsp;&nbsp;</span></td>
-                                <td *ngIf="!game.error && (game.rank != 'placement' || game.endSR) && !hideSR" class="num sr"><img src="assets/images/icons/{{ game.listView.rank }}.png"/><span>{{ game.listView.formatSR }}</span></td>
-                                <td *ngIf="!game.error" class="time"><div class="num">{{ getFormattedDuration(game) }}</div></td>
-                                <td *ngIf="!game.error" class="map {{map(game)}}">
-                                    <div class="map-wrap">
-                                        <div class="map-bg bg"></div>
-                                        <div class="map-title">
-                                            <div class="map-title-bg bg"></div>
-                                            <i>{{ game.map }}</i>
-                                        </div>
+                        <tr *ngFor="let game of gamesOfDay; trackBy: myTrackByFunction"
+                            id="game-{{ game.num }}"
+                            class="list-game"
+                            [class.sub-required]="!game.viewable"
+                            [class.hoverable]="!game.error"
+                            (mousedown)="prepRoute(game, $event)"
+                            (mouseup)="route(game, $event)"
+                            data-toggle="popover"
+                            tabindex="0"
+                        >
+                            <p display="False" style="display: none;">
+                                {{ game.key }}
+                            </p>
+                            <td class="gn">{{game.listView.formatTime}}</td>
+                            <td *ngIf="!game.error && !hideSR" class="{{game.listView.wltClass}} text-right num">
+                                <b>{{ game.listView.srChange }}</b>
+                            </td>
+                            <td *ngIf="!game.error && hideSR"></td>
+                            <td *ngIf="!game.error" class="{{game.listView.wltClass}} text-left" >{{ game.result }}</td>
+                            <td *ngIf="!game.error"><span class="num">{{ game.blueScore }}</span>/<span class="num">{{ game.redScore }}</span></td>
+                            <td *ngIf="!game.error && game.rank == 'placement' && !game.endSR && !hideSR" class="num sr"><img src="assets/images/icons/placement.png"/><span>&nbsp;&nbsp;&nbsp;&nbsp;</span></td>
+                            <td *ngIf="!game.error && (game.rank != 'placement' || game.endSR) && !hideSR" class="num sr"><img src="assets/images/icons/{{ game.listView.rank }}.png"/><span>{{ game.listView.formatSR }}</span></td>
+                            <td *ngIf="!game.error" class="time"><div class="num">{{ getFormattedDuration(game) }}</div></td>
+                            <td *ngIf="!game.error" class="map {{map(game)}}">
+                                <div class="map-wrap">
+                                    <div class="map-bg bg"></div>
+                                    <div class="map-title">
+                                        <div class="map-title-bg bg"></div>
+                                        <i>{{ game.map }}</i>
                                     </div>
-                                </td>
-                                <td *ngIf="!game.error" class="hero" style="position: relative">
-                                    <img *ngFor="let hero of game.heroes" src="assets/images/heroes/{{hero.name}}.png"/>
-                                    <span *ngIf="isOwnGames" (mousedown)="edit(game, $event)" class="game-edit glyphicon glyphicon-pencil"></span>
-                                </td>
-                                <td *ngIf="game.error" colspan="2" class="{{game.listView.wltClass}} text-left">{{game.result}}</td>
-                                <td *ngIf="game.error" colspan="5" class="error-message text-error">
-                                    <p>Game uploaded but failed to process. This is a bug. Please report this with the following game key: </p>
-                                    <pre>{{ game.key }}</pre>
-                                </td>
-                            </tr>
-                        </tbody>
+                                </div>
+                            </td>
+                            <td *ngIf="!game.error" class="hero" style="position: relative">
+                                <img *ngFor="let hero of game.heroes" src="assets/images/heroes/{{hero.name}}.png"/>
+                                <span *ngIf="isOwnGames" (mousedown)="edit(game, $event)" class="game-edit glyphicon glyphicon-pencil"></span>
+                            </td>
+                            <td *ngIf="game.error" colspan="2" class="{{game.listView.wltClass}} text-left">{{game.result}}</td>
+                            <td *ngIf="game.error" colspan="5" class="error-message text-error">
+                                <p>Game uploaded but failed to process. This is a bug. Please report this with the following game key: </p>
+                                <pre>{{ game.key }}</pre>
+                            </td>
+                        </tr>
                     </table>
                 </div>
             </div>

--- a/src/games-list/games-list.component.html
+++ b/src/games-list/games-list.component.html
@@ -42,11 +42,19 @@
                 </div>
                 <div *ngIf="isOwnGames" class="col-xs-6">
                     <div class="btn-group btn-group-toggle pull-left view-mode-buttons" data-toggle="buttons">
-                      <label class="btn btn-primary{{ isCompactView ? '' : ' active' }}" (click)="setIsCompact(false)">
+                      <label
+                          class="btn btn-primary{{ isCompactView ? '' : ' active' }}"
+                          (click)="setIsCompact(false)"
+                          title="Standard List View"
+                      >
                           <input type="radio" name="view-mode" class="btn btn-primary" id="thick-button">
                           <i class="glyphicon glyphicon-th-list"></i>
                       </label>
-                      <label class="btn btn-primary{{ isCompactView ? ' active' : '' }}" (click)="setIsCompact(true)">
+                      <label
+                          class="btn btn-primary{{ isCompactView ? ' active' : '' }}"
+                          (click)="setIsCompact(true)"
+                          title="Compact List View"
+                      >
                           <input type="radio" name="view-mode" class="btn btn-primary" id="compact-button">
                           <i class="glyphicon glyphicon-list"></i>
                       </label>

--- a/src/games-list/games-list.component.html
+++ b/src/games-list/games-list.component.html
@@ -118,7 +118,7 @@
                                 <p>Game uploading...</p>
                             </td> 
                         </tr>
-                        <tbody *ngFor="let gamesOfDay of gamesByDay">
+                        <tbody *ngFor="let gamesOfDay of gamesByDay" class="date-group">
                             <tr class="date-row"><th colspan="8">{{gamesOfDay[0].listView.formatDate}}</th></tr>
                             <tr style="width:100%">
                               <th>Game Time</th>

--- a/src/games-list/games-list.component.html
+++ b/src/games-list/games-list.component.html
@@ -24,63 +24,77 @@
 
     <edit-game [game]="gameToEdit" [leaveOnDelete]="false" [allowRename]="false" ></edit-game>
     <div class="row col-md-12">
-        <div>
-            <div class="col-xs-12">
-                <h2 style="float: left;">Games</h2>
-                <ng-multiselect-dropdown
-                    style="float: left; margin-left: 20px; margin-top: 15px; min-width: 240px;"
-                    [data]="allSeasons"
-                    [(ngModel)]="visibleSeasons"
-                    [settings]="dropdownSettings"
+        <div class="panel panel-default control-panel">
+            <div class="panel-heading">
+                <div class="col-xs-5">
+                    <h2 class="col-xs-3">Games</h2>
+                    <ng-multiselect-dropdown
+                        class="col-xs-9"
+                        [data]="allSeasons"
+                        [(ngModel)]="visibleSeasons"
+                        [settings]="dropdownSettings"
 
-                    (onSelect)="changeSeasonSelection($event)"
-                    (onDeSelect)="changeSeasonSelection($event)"
-                    (onDropDownClose)="closeDropdown($event)"
-                  >
-                  </ng-multiselect-dropdown>
-            </div>
-            <div *ngIf="isOwnGames" style="position: absolute; right: 0px; padding-top: 12px; padding-right: 30px;">
-                <share-links [accounts]="accountNames" class="pull-right"></share-links>
-                <integrations [accounts]="accountNames" class="pull-right"></integrations>
-                <button class="btn btn-primary" data-toggle="modal" data-target="#batch-edit" style="margin-right: 20px;">
-                    <span class="glyphicon glyphicon-pencil"></span>&nbsp; Batch Edit
-                </button>
+                        (onSelect)="changeSeasonSelection($event)"
+                        (onDeSelect)="changeSeasonSelection($event)"
+                        (onDropDownClose)="closeDropdown($event)"
+                      >
+                      </ng-multiselect-dropdown>
+                </div>
+                <div class="view-mode-buttons col-xs-2">
+                    <div class="btn-group btn-group-toggle" data-toggle="buttons">
+                      <label class="btn btn-primary{{ isCompactView ? '' : ' active' }}" (click)="setIsCompact(false)">
+                          <input type="radio" name="view-mode" class="btn btn-primary" id="thick-button">
+                          <i class="glyphicon glyphicon-th-list"></i>
+                      </label>
+                      <label class="btn btn-primary{{ isCompactView ? ' active' : '' }}" (click)="setIsCompact(true)">
+                          <input type="radio" name="view-mode" class="btn btn-primary" id="compact-button">
+                          <i class="glyphicon glyphicon-list"></i>
+                      </label>
+                    </div>
+                </div>
+                <div *ngIf="isOwnGames" class="col-xs-5">
+                    <share-links [accounts]="accountNames" class="pull-right"></share-links>
+                    <integrations [accounts]="accountNames" class="pull-right"></integrations>
+                    <button class="btn btn-primary pull-right" data-toggle="modal" data-target="#batch-edit">
+                        <span class="glyphicon glyphicon-pencil"></span>&nbsp; Batch Edit
+                    </button>
 
-                <div id="batch-edit" class="modal fade bd-example-modal-sm" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel2" aria-hidden="true">
-                    <div class="modal-dialog modal-sm">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <h4 class="modal-title" id="mySmallModalLabel2" style="display: inline">Batch Edit</h4>
-                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                <span aria-hidden="true">×</span>
-                                </button>
-                            </div>
-                            <div class="modal-body">
-                                <div class="form-group row">
-                                    <label for="account-input" class="col-2 col-form-label">Account</label>
-                                    <div class="col-10">
-                                        <select id="account-input" class="form-control">
-                                            <option *ngFor="let games of gamesLists">{{ games.player }}</option>
-                                        </select> 
-                                    </div>
+                    <div id="batch-edit" class="modal fade bd-example-modal-sm" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel2" aria-hidden="true">
+                        <div class="modal-dialog modal-sm">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h4 class="modal-title" id="mySmallModalLabel2" style="display: inline">Batch Edit</h4>
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">×</span>
+                                    </button>
                                 </div>
+                                <div class="modal-body">
+                                    <div class="form-group row">
+                                        <label for="account-input" class="col-2 col-form-label">Account</label>
+                                        <div class="col-10">
+                                            <select id="account-input" class="form-control">
+                                                <option *ngFor="let games of gamesLists">{{ games.player }}</option>
+                                            </select>
+                                        </div>
+                                    </div>
 
-                                <div class="form-group row">
-                                    <label for="playername-input" class="col-2 col-form-label">Player Name</label>
-                                    <div class="col-10" style="background: red; border-radius: 4px;">
-                                        <input class="form-control" type="text" value="" id="playername-input">
+                                    <div class="form-group row">
+                                        <label for="playername-input" class="col-2 col-form-label">Player Name</label>
+                                        <div class="col-10" style="background: red; border-radius: 4px;">
+                                            <input class="form-control" type="text" value="" id="playername-input">
+                                        </div>
                                     </div>
-                                </div>
-                                <div class="row">
-                                    <div class="col-lg-6" style="padding: 2px;">
-                                        <button class="btn btn-danger" (click)="batchEdit('delete')">
-                                            Delete
-                                        </button>
-                                    </div>
-                                    <div class="col-lg-6" style="padding: 2px;">
-                                        <button class="btn btn-info pull-right" style="margin-left: 83%" (click)="batchEdit('rename')">
-                                            Rename
-                                        </button>
+                                    <div class="row">
+                                        <div class="col-lg-6" style="padding: 2px;">
+                                            <button class="btn btn-danger" (click)="batchEdit('delete')">
+                                                Delete
+                                            </button>
+                                        </div>
+                                        <div class="col-lg-6" style="padding: 2px;">
+                                            <button class="btn btn-info pull-right" style="margin-left: 83%" (click)="batchEdit('rename')">
+                                                Rename
+                                            </button>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -109,7 +123,7 @@
             </div>
             <div class="panel-body">
                 <div class="tab-content">
-                    <table class="table table-striped text-center">
+                    <table class="table table-striped text-center{{ isCompactView ? ' compact' : '' }}">
                         <tr *ngIf="currentUploadRequested && currentUserID == games.user_id">
                             <td class="gn">{{formatTime(currentUploadRequested)}} {{ formatDay(currentUploadRequested) }}<br>
                                 {{formatDate(currentUploadRequested)}}

--- a/src/games-list/games-list.component.ts
+++ b/src/games-list/games-list.component.ts
@@ -34,6 +34,7 @@ export class GamesListComponent implements OnInit, AfterContentChecked {
     showUploadingGames = true;
     currentUploadRequested: Date = null;
     currentUserID: number;
+    isCompactView: boolean = false;
 
     gameToEdit: Game = null;
 
@@ -76,6 +77,7 @@ export class GamesListComponent implements OnInit, AfterContentChecked {
                 }             
             }
         );
+        this.isCompactView = (sessionStorage.getItem('isCompactView') === 'true');
     }
 
     rank(sr: number) {
@@ -508,5 +510,16 @@ export class GamesListComponent implements OnInit, AfterContentChecked {
                 throw err;
             }
         );
+    }
+
+    setIsCompact(isCompact) {
+        this.isCompactView = isCompact;
+        sessionStorage.setItem('isCompactView', isCompact);
+
+        if (isCompact) {
+            $('#gametable table').addClass('compact');
+        } else {
+            $('#gametable table').removeClass('compact');
+        }
     }
 }

--- a/src/games-list/games-list.service.ts
+++ b/src/games-list/games-list.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams  } from '@angular/common/http';
+import * as moment from 'moment';
 
 import { Game } from '../game/game.service';
 
@@ -32,29 +33,15 @@ export class GamesListService {
     }
 
     formatTime(date: Date) {
-        let hour = date.getHours();
-        const pm = hour > 11;
-        hour = hour % 12;
-        hour = hour === 0 ? 12 : hour;
-        let min: number|string = date.getMinutes();
-        if (min < 10){
-            min = '0' + min;
-        }
-        return hour + ':' + min + (pm ? 'pm' : 'am');
+        return moment(date).format('LT');
     }
     
     formatDate(date: Date) {
-        return date.toLocaleDateString(undefined, {
-            year: '2-digit',
-            month: 'numeric',
-            day: 'numeric'
-
-        });
+        return moment(date).format('dddd, LL');
     }
 
     formatDay(date: Date) {
-        var days = ['Sun','Mon','Tues','Wed','Thurs','Fri','Sat'];
-        return days[date.getDay()]
+        return moment(date).format('ddd');
     }
 
     rank(sr: number) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -30,9 +30,14 @@ a.navbar-brand > img {
     /* visibility: hidden; */
     display: none !important;
     position: absolute !important;
+    right: 2px !important;
+    top: 35px !important;
+    font-size: 10pt !important;
+}
+
+.compact .game-edit {
     right: 4px !important;
     top: 18px !important;
-    font-size: 10pt !important;
 }
 
 .tab-stats-table > tbody > tr > td,
@@ -376,6 +381,24 @@ a.navbar-brand > img {
     border-top: 1px solid #697075;
 }
 
+.control-panel h2 {
+  padding-left: 0;
+  margin: 0;
+}
+
+.control-panel button, .control-panel .view-mode-buttons label {
+  height: 38px;
+}
+
+.control-panel > .panel-heading {
+  height: 66px;
+  padding-top: 16px;
+}
+
+.control-panel {
+  margin-bottom: 0;
+}
+
 #gametable {
     width: 100%;
 }
@@ -385,10 +408,14 @@ a.navbar-brand > img {
 }
 
 #gametable td {
-    font-size:18px;
+    font-size:26px;
     vertical-align: middle;
     padding-top: 0px;
     padding-bottom: 0px;
+}
+
+#gametable .compact td {
+  font-size:18px;
 }
 
 #gametable .date-row {
@@ -402,7 +429,11 @@ a.navbar-brand > img {
 }
 
 #gametable .sr img {
-    height:25px;
+    height: 30px;
+}
+
+#gametable .compact .sr img {
+  height: 25px;
 }
 
 #gametable .time {
@@ -545,13 +576,17 @@ a.navbar-brand > img {
 
 #gametable .map {
     text-align: left;
-    font-size:18px;
+    font-size: 26px;
     text-shadow: 1px 1px 10px black;
     color:lightgray;
     padding: 0;
 }
 
-#gametable .map .bg {
+#gametable .compact .map {
+    font-size: 18px;
+}
+
+#gametable .compact .map .bg {
     background-position: center 67%;
 }
 
@@ -560,16 +595,24 @@ a.navbar-brand > img {
     overflow: hidden;
     background-size: cover;
     background-position: 0 0, center;
-    height: 30px;
+    height: 48px;
     margin: 2px 0 2px 0;
+}
+
+#gametable .compact .map-wrap {
+    height: 30px;
 }
 
 #gametable .map-bg {
     position: absolute;
-    height: 28px;
+    height: 52px;
     width: 310px;
     z-index: 0;
     filter: blur(2px) brightness(75%);
+}
+
+#gametable .compact .map-bg {
+    height: 28px;
 }
 
 #gametable .map-title {
@@ -577,8 +620,12 @@ a.navbar-brand > img {
     padding-left: 20px;
     position: relative;
     padding-right: 20px;
-    top: 2px;
+    top: 6px;
     z-index: 1;
+}
+
+#gametable .compact .map-title {
+    top: 2px;
 }
 
 #gametable .map-title-bg {
@@ -817,6 +864,10 @@ a.navbar-brand > img {
 }
 
 #gametable .hero > img {
+    height: 48px;
+}
+
+#gametable .compact .hero > img {
     height: 30px;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -30,8 +30,8 @@ a.navbar-brand > img {
     /* visibility: hidden; */
     display: none !important;
     position: absolute !important;
-    right: 2px !important;
-    top: 35px !important;
+    right: 4px !important;
+    top: 18px !important;
     font-size: 10pt !important;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -392,8 +392,7 @@ a.navbar-brand > img {
 }
 
 #gametable .date-row {
-    font-size: 18px;
-    height: 25px;
+    font-size: 16px;
     vertical-align: middle;
     background-color: transparent;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -385,44 +385,23 @@ a.navbar-brand > img {
 }
 
 #gametable td {
-    font-size:35px;
+    font-size:26px;
     vertical-align: middle;
     padding-top: 0px;
     padding-bottom: 0px;
 }
 
-#gametable .gn {
-    font-size:18px;
+#gametable .date-row {
+    height: 53px;
 }
 
-#gametable .sr {
-    font-size:25px;
-    line-height:30px;
-    padding-top:5px;
-    padding-bottom:0px;
-}
-
-#gametable .sr > img {
-    height:45px;
-}
-
-#gametable .sr > span {
-    line-height: 25px;
+#gametable .sr img {
+    height:30px;
 }
 
 #gametable .time {
     padding-top:0px;
     padding-bottom:0px;
-}
-
-#gametable .time > .num {
-    font-size:25px;
-    line-height: 18px;
-    padding-top: 8px;
-}
-
-#gametable .time > .unit{
-    font-size: 18px;
 }
 
 .unit {
@@ -828,7 +807,7 @@ a.navbar-brand > img {
 }
 
 #gametable .hero > img {
-    height: 50px;
+    height: 48px;
 }
 
 /*

--- a/src/styles.css
+++ b/src/styles.css
@@ -392,7 +392,10 @@ a.navbar-brand > img {
 }
 
 #gametable .date-row {
+    font-size: 26px;
     height: 53px;
+    vertical-align: middle;
+    background-color: transparent;
 }
 
 #gametable .sr img {
@@ -914,7 +917,7 @@ path.js-line {
 }
 
 .table-striped > tbody > tr:nth-of-type(odd) {
-    background-color: #4a5561 !important;
+    background-color: #4a5561
 }
 
 .text-success, .text-success:hover {

--- a/src/styles.css
+++ b/src/styles.css
@@ -385,21 +385,25 @@ a.navbar-brand > img {
 }
 
 #gametable td {
-    font-size:26px;
+    font-size:18px;
     vertical-align: middle;
     padding-top: 0px;
     padding-bottom: 0px;
 }
 
 #gametable .date-row {
-    font-size: 26px;
-    height: 53px;
+    font-size: 18px;
+    height: 25px;
     vertical-align: middle;
     background-color: transparent;
 }
 
+#gametable .date-group~.date-group .date-row th {
+    padding-top: 10px;
+}
+
 #gametable .sr img {
-    height:30px;
+    height:25px;
 }
 
 #gametable .time {
@@ -542,10 +546,14 @@ a.navbar-brand > img {
 
 #gametable .map {
     text-align: left;
-    font-size:26px;
+    font-size:18px;
     text-shadow: 1px 1px 10px black;
     color:lightgray;
     padding: 0;
+}
+
+#gametable .map .bg {
+    background-position: center 67%;
 }
 
 #gametable .map-wrap {
@@ -553,13 +561,13 @@ a.navbar-brand > img {
     overflow: hidden;
     background-size: cover;
     background-position: 0 0, center;
-    height: 48px;
+    height: 30px;
     margin: 2px 0 2px 0;
 }
 
 #gametable .map-bg {
     position: absolute;
-    height: 52px;
+    height: 28px;
     width: 310px;
     z-index: 0;
     filter: blur(2px) brightness(75%);
@@ -570,7 +578,7 @@ a.navbar-brand > img {
     padding-left: 20px;
     position: relative;
     padding-right: 20px;
-    top: 6px;
+    top: 2px;
     z-index: 1;
 }
 
@@ -810,7 +818,7 @@ a.navbar-brand > img {
 }
 
 #gametable .hero > img {
-    height: 48px;
+    height: 30px;
 }
 
 /*


### PR DESCRIPTION
Changed the font sizes of the table cells in the rows of the games list to all be the same size.

Removed the date from each row, as that was redundant data, and instead added a header row at the beginning of each new day to break up the list.

Added a toggle switch for making the rows more narrow with a smaller font.  The preference is saved to the user's session, so should persist between page loads.