### PR TITLE
Use local storage for compact view toggle

### DIFF
--- a/src/games-list/games-list.component.ts
+++ b/src/games-list/games-list.component.ts
@@ -77,7 +77,7 @@ export class GamesListComponent implements OnInit, AfterContentChecked {
                 }             
             }
         );
-        this.isCompactView = (sessionStorage.getItem('isCompactView') === 'true');
+        this.isCompactView = (localStorage.getItem('isCompactView') === 'true');
     }
 
     rank(sr: number) {
@@ -514,7 +514,7 @@ export class GamesListComponent implements OnInit, AfterContentChecked {
 
     setIsCompact(isCompact) {
         this.isCompactView = isCompact;
-        sessionStorage.setItem('isCompactView', isCompact);
+        localStorage.setItem('isCompactView', isCompact);
 
         if (isCompact) {
             $('#gametable table').addClass('compact');


### PR DESCRIPTION
Use local storage instead of previously used session storage to keep the user's choice persistent.

This has been tested locally.

Fixes #41 