### PR TITLE
Fix current player tab not updating

### DIFF
--- a/src/win-rates/win-rates.component.ts
+++ b/src/win-rates/win-rates.component.ts
@@ -75,7 +75,16 @@ export class WinRatesComponent implements OnInit {
     updateSeasonGames(res: PlayerGameList[], seasons: string[]) {
         this.gamesLists = res;
         this.seasons = seasons;
-        this.calcWinrates();
+
+        let player = this.gamesLists[0];
+        for (let gl of this.gamesLists) {
+            if (gl.player === this.currentPlayer.player) {
+                player = gl;
+                break;
+            }
+        }
+
+        this.selectPlayer(player);
     }
 
     changeSeasonSelection(event) {


### PR DESCRIPTION
The current tab at time of season selection would not be affected until the tab is selected. This resolves that bug by correctly updating the current tab on season selection.